### PR TITLE
CSS-81 [QA] 항해_간헐적으로 크래시가 일어나는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
@@ -28,6 +28,11 @@ void ASailingSystem::BeginPlay()
 void ASailingSystem::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+
+	if (MyShip == nullptr)
+	{
+		return;
+	}
 	
 	if (ClearTrigger->IsTriggered())
 	{


### PR DESCRIPTION
무작위하게 MyShip의 Begin보다 SailingSystem의 Tick()이 우선적으로 실행됨.
SailingSystem의 Tick에서 MyShip의 무결성 검사 추가