### PR TITLE
CSS-212 [QA] 컴파일 시 appError called 발생

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/Map/Obstacle.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Map/Obstacle.cpp
@@ -1,13 +1,12 @@
 ﻿#include "Obstacle.h"
 
+// Todo@autumn - Declare obstacle classes
+
 AObstacle::AObstacle() : MeshComponent(nullptr)
 {
 	// TODO@autumn - This is a temporary mesh, replace it with the actual mesh from data
 	
-	const auto Random = FMath::RandRange(1, 3);
-	const auto Name = FString::Printf(TEXT("/Game/GameObjects/Terrain/Rock%d.Rock%d"), Random, Random);
-	
 	MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
-	MeshComponent->SetStaticMesh(LoadObject<UStaticMesh>(nullptr, *Name));
+	MeshComponent->SetStaticMesh(LoadObject<UStaticMesh>(nullptr, TEXT("/Script/Engine.StaticMesh'/Game/GameObjects/Terrain/Rock1.Rock1'")));
 	RootComponent = MeshComponent;
 }


### PR DESCRIPTION
생성자에서 MeshComponent 포인터에 여러 에셋 중 한 가지를 할당할 수 있게 하는 것이 최초 인덱싱에서 문제를 일으키는 것으로 추정, 향후 여러 클래스를 사용하도록 작성 필요