### PR TITLE
CSS-244 [QA] 적 대포알이 바다에 명중 시 사라지지 않음

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/Object/EnemyShipCannonBall.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Object/EnemyShipCannonBall.cpp
@@ -38,7 +38,9 @@ void AEnemyShipCannonBall::Tick(float DeltaTime)
 void AEnemyShipCannonBall::OnHit(UPrimitiveComponent* HitComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp,
 	FVector NormalImpulse, const FHitResult& Hit)
 {
-
+	FTimerHandle TimerHandle;
+	GetWorld()->GetTimerManager().SetTimer(TimerHandle, this, &ThisClass::DestroyWithDelay, DestroyDelayTime, false);
+	
 	AMyShip* MyShip = Cast<AMyShip>(OtherActor);
 	if(MyShip == nullptr)
 	{
@@ -50,9 +52,6 @@ void AEnemyShipCannonBall::OnHit(UPrimitiveComponent* HitComponent, AActor* Othe
 	MyShip->Damage(1); // Todo@autumn - This is a temporary solution, replace it with data.
 	
 	StaticMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-
-	FTimerHandle TimerHandle;
-	GetWorld()->GetTimerManager().SetTimer(TimerHandle, this, &ThisClass::DestroyWithDelay, DestroyDelayTime, false);
 }
 
 void AEnemyShipCannonBall::DestroyWithDelay()


### PR DESCRIPTION
적 포탄이 배와 명중한 여부와 관계 없이 항상 Destroy를 실행하도록 수정