### PR TITLE
CSS-242 [QA] 클라이언트의 해적이 부활하지 못하는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/MyCharacter.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyCharacter.cpp
@@ -222,6 +222,9 @@ void AMyCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLife
 
 	DOREPLIFETIME(AMyCharacter, bIsSleeping);
 	DOREPLIFETIME(AMyCharacter, CurrentAttackCooldown);
+	DOREPLIFETIME(AMyCharacter, MaxHP);
+	DOREPLIFETIME(AMyCharacter, CurrentHP);
+	DOREPLIFETIME(AMyCharacter, CurrentPlayerState);
 }
 
 void AMyCharacter::SetNamePlate()

--- a/capstone_2024_20/Source/capstone_2024_20/MyCharacter.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyCharacter.h
@@ -74,7 +74,10 @@ protected:
 	
 private:
 	// [begin] IHP interface
+	UPROPERTY(Replicated)
 	int32 MaxHP = 0;
+	
+	UPROPERTY(Replicated)
 	int32 CurrentHP = 0;
 	// [end] IHP interface
 
@@ -113,7 +116,8 @@ public:
 		TEXT("Upgrade"),
 		TEXT("FireEvent")
 	};
-	
+
+	UPROPERTY(Replicated)
 	UserState CurrentPlayerState = UserState::NONE;
 
 	UserState GetCurrentPlayerState() const;


### PR DESCRIPTION
체력, State 관련 변수를 Replicate하여 해결. Client에서 해당 변수를 서버에서 변경된 값으로 가지고 있지 않았던 것이 원인.