### PR TITLE
CSS-247 [QA] 항해_적 배_배가 이동 중일 때 적을 생성하면 크래시가 일어나는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.h
+++ b/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.h
@@ -36,11 +36,13 @@ public:
 	void MoveToMyShip(const AMyShip* MyShip, const float DeltaTime);
 	void LookAtMyShip(const AMyShip* MyShip);
 	void FireCannon(const float DeltaTime);
-	AEnemy* SpawnEnemy(AActor* MyShip, const float DeltaTime) const;
+	AEnemy* SpawnEnemy(AMyShip* MyShip);
 
 	bool CanMove(const AMyShip* MyShip) const;
-	bool CanSpawnEnemy() const;
+	bool CanSpawnEnemy(const AMyShip* MyShip) const;
 	bool CanFireCannon() const;
+
+	void ReduceSpawnEnemyCooldown(const float DeltaTime);
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	bool bCanSpawnEnemy = false;
@@ -62,11 +64,13 @@ private:
 	int32 CurrentHP = 0;
 	// [end] IHP interface
 	
-	inline static float SpawnEnemyTimer = 0.0f;
 	inline static float FireCannonTimer = 0.0f;
 
 	inline static float DistanceToMyShip = 7000.0f;
 	inline static float MoveSpeed = 400.0f;
+
+	const float SpawnEnemyCooldown = 5.0f;
+	float CurrentSpawnEnemyCooldown = 0.0f;
 	
 	UPROPERTY()
 	UArrowComponent* ProjectileSpawnPoint;

--- a/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
@@ -127,14 +127,14 @@ void ASailingSystem::Tick(float DeltaTime)
 			EnemyShip->FireCannon(DeltaTime);
 		}
 
-		if (EnemyShip->CanSpawnEnemy())
+		if (EnemyShip->CanSpawnEnemy(MyShip))
 		{
-			if (const auto SpawnedEnemy = EnemyShip->SpawnEnemy(MyShip, DeltaTime); SpawnedEnemy != nullptr)
-			{
-				Enemies.Add(SpawnedEnemy);
-				SpawnedEnemy->EnemyDieDelegate.BindUObject(this, &ASailingSystem::OnEnemyDie);
-			}
+			const auto SpawnedEnemy = EnemyShip->SpawnEnemy(MyShip);
+			Enemies.Add(SpawnedEnemy);
+			SpawnedEnemy->EnemyDieDelegate.BindUObject(this, &ASailingSystem::OnEnemyDie);
 		}
+
+		EnemyShip->ReduceSpawnEnemyCooldown(DeltaTime);
 	}
 
 	for (const auto Enemy : Enemies)


### PR DESCRIPTION
적 스폰이 nullable하지 않도록 수정, 이를 위해 적 생성 쿨다운을 변수로 관리