### PR TITLE
CSS-260 [프로그램][개선] 항해_이벤트_모델 수정

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/Event/Event.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Event/Event.cpp
@@ -7,6 +7,7 @@ AEvent::AEvent(): Particle(nullptr), BoxComponent(nullptr)
 	// TODO@autumn - This is a temporary mesh, replace it with the actual mesh from data
 	Particle = CreateDefaultSubobject<UParticleSystemComponent>(TEXT("ParticleSystem"));
 	Particle->SetTemplate(LoadObject<UParticleSystem>(nullptr, TEXT("/Script/Engine.ParticleSystem'/Game/Particles/Realistic_Starter_VFX_Pack_Vol2/Particles/Fire/P_Fire_Big.P_Fire_Big'")));
+	Particle->SetRelativeScale3D(AdjustedScale);
 	RootComponent = Particle;
 
 	BoxComponent = CreateDefaultSubobject<UBoxComponent>(TEXT("BoxComponent"));

--- a/capstone_2024_20/Source/capstone_2024_20/Event/Event.h
+++ b/capstone_2024_20/Source/capstone_2024_20/Event/Event.h
@@ -23,4 +23,6 @@ private:
 
 	UPROPERTY(EditAnywhere)
 	UBoxComponent* BoxComponent;
+
+	FVector AdjustedScale = FVector(0.4f, 0.4f, 0.4f);
 };


### PR DESCRIPTION
현재 불 이벤트로 사용하는 이펙트의 크기가 지나치게 거대하나, 새로운 이펙트를 찾을 여유 시간이 부족하여 스케일을 변경하여 사용