### PR TITLE
CSS-285 [QA] 항해_업그레이드_클라이언트에서 UI가 작동하지 않는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/MyIngameHUD.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyIngameHUD.cpp
@@ -5,6 +5,11 @@
 
 void AMyIngameHUD::BeginPlay()
 {
+	if (bIsCalledBeginPlay)
+	{
+		return;
+	}
+	
 	Super::BeginPlay();
 
 	InGameWidget = CreateWidget<UUserWidget>(GetWorld(), IngameWidgetClass);
@@ -18,6 +23,8 @@ void AMyIngameHUD::BeginPlay()
 
 	EnemyShipProgressBar = Cast<UProgressBar>(InGameWidget->GetWidgetFromName(TEXT("EnemyShipHPProgressBar")));
 	EnemyShipProgressBar->SetVisibility(ESlateVisibility::Hidden);
+	
+	bIsCalledBeginPlay = true;
 }
 
 void AMyIngameHUD::SetPopupDeadVisibility(const bool bIsVisible) const

--- a/capstone_2024_20/Source/capstone_2024_20/MyIngameHUD.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyIngameHUD.h
@@ -59,4 +59,8 @@ private:
 
 	UPROPERTY()
 	UProgressBar* EnemyShipProgressBar;
+
+	// ! 일부 클래스에서, HUD의 BeginPlay가 늦게 호출되는 경우가 있어 해당 클래스에서는 BeginPlay를 직접 호출.
+	// ! 이때, BeginPlay가 이미 호출된 경우에는 다시 호출하지 않도록 예외 처리하기 위한 변수
+	bool bIsCalledBeginPlay = false;
 };

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -407,16 +407,6 @@ void AMyPlayerController::Attack(const FInputActionInstance& Instance)
 	ServerRPC_Attack();
 }
 
-void AMyPlayerController::InteractOnClient(AMyObject* OBJ)
-{
-	OBJ->Interact();
-}
-
-void AMyPlayerController::InteractOnServer(AMyObject* OBJ)
-{
-	ServerRPC_InteractOnServer(OBJ);
-}
-
 void AMyPlayerController::UpgradeMyShipMoveSpeed()
 {
 	ServerRPC_UpgradeMyShipMoveSpeed();
@@ -430,6 +420,16 @@ void AMyPlayerController::UpgradeMyShipHandling()
 void AMyPlayerController::UpgradeMyShipCannonAttack()
 {
 	ServerRPC_UpgradeMyShipCannonAttack();
+}
+
+void AMyPlayerController::InteractOnClient(AMyObject* OBJ)
+{
+	OBJ->Interact();
+}
+
+void AMyPlayerController::InteractOnServer(AMyObject* OBJ)
+{
+	ServerRPC_InteractOnServer(OBJ);
 }
 
 void AMyPlayerController::ServerRPC_Attack_Implementation()

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -4,6 +4,9 @@
 #include "ShipControlStrategy.h"
 #include "Kismet/GameplayStatics.h"
 #include "InputMappingContext.h"
+#include "MyIngameHUD.h"
+#include "Sailing/SailingSystem.h"
+#include "Upgrade/UpgradeWidgetElement.h"
 
 class AStaticMeshActor;
 
@@ -80,6 +83,19 @@ void AMyPlayerController::BeginPlay()
 	if(Ship)
 	{
 		SetViewTarget(Ship->Camera_Character);
+	}
+
+	if (IsLocalController())
+	{
+		SailingSystem = Cast<ASailingSystem>(UGameplayStatics::GetActorOfClass(GetWorld(), ASailingSystem::StaticClass()));
+		
+		MyInGameHUD = Cast<AMyIngameHUD>(GetHUD());
+		MyInGameHUD->BeginPlay();
+	
+		const UUpgradeWidget* PopupUpgrade = MyInGameHUD->GetPopupUpgrade();
+		PopupUpgrade->SpeedUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipMoveSpeed);
+		PopupUpgrade->HandlingUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipHandling);
+		PopupUpgrade->CannonAttackUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipCannonAttack);
 	}
 	
 	EnableCheats();
@@ -401,6 +417,21 @@ void AMyPlayerController::InteractOnServer(AMyObject* OBJ)
 	ServerRPC_InteractOnServer(OBJ);
 }
 
+void AMyPlayerController::UpgradeMyShipMoveSpeed()
+{
+	ServerRPC_UpgradeMyShipMoveSpeed();
+}
+
+void AMyPlayerController::UpgradeMyShipHandling()
+{
+	ServerRPC_UpgradeMyShipHandling();
+}
+
+void AMyPlayerController::UpgradeMyShipCannonAttack()
+{
+	ServerRPC_UpgradeMyShipCannonAttack();
+}
+
 void AMyPlayerController::ServerRPC_Attack_Implementation()
 {
 	if (HasAuthority())
@@ -543,6 +574,21 @@ void AMyPlayerController::PlayerAwake()
 	Bed->AwakeSound();
 	
 	GetWorld()->GetTimerManager().ClearTimer(HealthTimerHandle);
+}
+
+void AMyPlayerController::ServerRPC_UpgradeMyShipMoveSpeed_Implementation()
+{
+	SailingSystem->UpgradeMyShipMoveSpeed();
+}
+
+void AMyPlayerController::ServerRPC_UpgradeMyShipHandling_Implementation()
+{
+	SailingSystem->UpgradeMyShipHandling();
+}
+
+void AMyPlayerController::ServerRPC_UpgradeMyShipCannonAttack_Implementation()
+{
+	SailingSystem->UpgradeMyShipCannonAttack();
 }
 
 void AMyPlayerController::ServerRPC_PlayerAwake_Implementation(AMyCharacter* user, bool b, AMyBed* bed)

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -85,10 +85,10 @@ void AMyPlayerController::BeginPlay()
 		SetViewTarget(Ship->Camera_Character);
 	}
 
+	SailingSystem = Cast<ASailingSystem>(UGameplayStatics::GetActorOfClass(GetWorld(), ASailingSystem::StaticClass()));
+	
 	if (IsLocalController())
 	{
-		SailingSystem = Cast<ASailingSystem>(UGameplayStatics::GetActorOfClass(GetWorld(), ASailingSystem::StaticClass()));
-		
 		MyInGameHUD = Cast<AMyIngameHUD>(GetHUD());
 		MyInGameHUD->BeginPlay();
 	

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
@@ -12,6 +12,10 @@
 #include "MyBed.h"
 #include "MyPlayerController.generated.h"
 
+class ASailingSystem;
+// ReSharper disable once IdentifierTypo
+class AMyIngameHUD;
+
 UCLASS()
 class CAPSTONE_2024_20_API AMyPlayerController : public APlayerController
 {
@@ -48,6 +52,12 @@ private:
 
 	UPROPERTY(Category=Input, VisibleAnywhere)
 	UInputAction* AttackAction;
+
+	UPROPERTY()
+	ASailingSystem* SailingSystem;
+
+	UPROPERTY()
+	AMyIngameHUD* MyInGameHUD;
 	
 public:
 	UPROPERTY(Category=UI, VisibleAnywhere)
@@ -87,6 +97,10 @@ public:
 	void Move(const FInputActionInstance& Instance);
 	void Shoot(const FInputActionInstance& Instance);
 	void Attack(const FInputActionInstance& Instance);
+
+	void UpgradeMyShipMoveSpeed();
+	void UpgradeMyShipHandling();
+	void UpgradeMyShipCannonAttack();
 	
 	static void InteractOnClient(AMyObject* OBJ);
 	void InteractOnServer(AMyObject* OBJ);
@@ -141,6 +155,15 @@ public:
 
 	UFUNCTION(Server, Reliable)
 	void ServerRPC_PlayerAwake(AMyCharacter* user, bool b, AMyBed* bed);
+
+	UFUNCTION(Server, Reliable)
+	void ServerRPC_UpgradeMyShipMoveSpeed();
+
+	UFUNCTION(Server, Reliable)
+	void ServerRPC_UpgradeMyShipHandling();
+
+	UFUNCTION(Server, Reliable)
+	void ServerRPC_UpgradeMyShipCannonAttack();
 
 protected:
 	enum class ControlMode

--- a/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.cpp
@@ -10,8 +10,6 @@
 #include "../Map/Map.h"
 #include "../Map/Grid.h"
 #include "../Object/Destination.h"
-#include "../MyIngameHUD.h"
-#include "../Upgrade/UpgradeWidgetElement.h"
 #include "Net/UnrealNetwork.h"
 #include "../Event/Event.h"
 
@@ -33,14 +31,11 @@ void ASailingSystem::BeginPlay()
 	
 	CreateMap();
 
-	MyInGameHUD = Cast<AMyIngameHUD>(GetWorld()->GetFirstPlayerController()->GetHUD());
-
 	// To ensure that the ship is set before sailing system starts, run SetMyShip on world begin play
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &ASailingSystem::SetMyShip);
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &ASailingSystem::SetMyCharacters);
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &ASailingSystem::SetEnemyShips);
 	GetWorld()->OnWorldBeginPlay.AddUObject(this, &ASailingSystem::SetDestination);
-	GetWorld()->OnWorldBeginPlay.AddUObject(this, &ASailingSystem::AddDelegateToPopupUpgrade);
 }
 
 // ReSharper disable once CppParameterMayBeConst
@@ -253,14 +248,6 @@ void ASailingSystem::UseCurrency(const int32 Amount)
 int ASailingSystem::GetCurrency() const
 {
 	return Currency;
-}
-
-void ASailingSystem::AddDelegateToPopupUpgrade()
-{
-	const UUpgradeWidget* PopupUpgrade = MyInGameHUD->GetPopupUpgrade();
-	PopupUpgrade->SpeedUpgrade->OnClickUpgradeDelegate.AddUObject(this, &ASailingSystem::UpgradeMyShipMoveSpeed);
-	PopupUpgrade->HandlingUpgrade->OnClickUpgradeDelegate.AddUObject(this, &ASailingSystem::UpgradeMyShipHandling);
-	PopupUpgrade->CannonAttackUpgrade->OnClickUpgradeDelegate.AddUObject(this, &ASailingSystem::UpgradeMyShipCannonAttack);
 }
 
 void ASailingSystem::AddSpawnedEventFromEnemyShipCannonBall(AEvent* Event)

--- a/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.h
+++ b/capstone_2024_20/Source/capstone_2024_20/Sailing/SailingSystem.h
@@ -44,7 +44,6 @@ public:
 	UFUNCTION(BlueprintPure)
 	int GetCurrency() const;
 
-	void AddDelegateToPopupUpgrade();
 	void AddSpawnedEventFromEnemyShipCannonBall(AEvent* Event);
 
 	void UpgradeMyShipMoveSpeed();
@@ -106,7 +105,4 @@ private:
 	FVector InitLocation;
 	UPROPERTY(Replicated)
 	float Progress = 0.0f;
-	
-	UPROPERTY()
-	AMyIngameHUD* MyInGameHUD = nullptr;
 };


### PR DESCRIPTION
업그레이드 로직을 서버에서 사용하기 위해, PlayerController에서 SailingSystem과 HUD를 참조하도록 작성
- 기존 로직은 SailingSystem 내부에서 호출하였으나, SailingSystem Actor는 server-owned로 클라이언트에서 Server RPC 함수를 호출할 수 없었던 것이 원인.