### PR TITLE
CSS-327 [QA] Navigation으로 이동할 때, 회전이 어색한 문제 

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
@@ -150,8 +150,10 @@ void AEnemyShip::MoveToMyShip(const AMyShip* MyShip, const float DeltaTime)
 
 bool AEnemyShip::CanMove(const AMyShip* MyShip) const
 {
-	const auto MyShipLocation = MyShip->GetActorLocation();
-	const auto Direction = MyShipLocation - GetActorLocation();
+	const auto EnemyShipHeadLocation = FindComponentByClass<UEnemyShipHead>()->GetComponentLocation();
+	const auto NearestMovePointLocation = MyShip->GetNearestEnemyShipMovePointLocationFrom(EnemyShipHeadLocation);
+	const auto Direction = NearestMovePointLocation - GetActorLocation();
+	
 	return Direction.Size() > DistanceToMyShip && Direction.Size() < DistanceToObserveMyShip;
 }
 
@@ -162,8 +164,9 @@ bool AEnemyShip::CanSpawnEnemy(const AMyShip* MyShip) const
 
 bool AEnemyShip::CanFireCannon(const AMyShip* MyShip) const
 {
-	const auto MyShipLocation = MyShip->GetActorLocation();
-	const auto Direction = MyShipLocation - GetActorLocation();
+	const auto EnemyShipHeadLocation = FindComponentByClass<UEnemyShipHead>()->GetComponentLocation();
+	const auto NearestMovePointLocation = MyShip->GetNearestEnemyShipMovePointLocationFrom(EnemyShipHeadLocation);
+	const auto Direction = NearestMovePointLocation - GetActorLocation();
 	
 	return bCanFireCannon && Direction.Size() < DistanceToMyShip;
 }

--- a/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
@@ -142,9 +142,10 @@ void AEnemyShip::MoveToMyShip(const AMyShip* MyShip, const float DeltaTime)
 	const FVector NextPoint = PathToMyShip->PathPoints[1];
 	const FVector DirectionToNextPoint = NextPoint - GetActorLocation();
 	const FVector NewLocation = GetActorLocation() + DirectionToNextPoint.GetSafeNormal() * MoveSpeed * DeltaTime;
+	const auto NewRotation = FRotationMatrix::MakeFromX(DirectionToNextPoint).Rotator();
 	
 	SetActorLocation(NewLocation);
-	SetActorRotation(DirectionToNextPoint.Rotation());
+	SetActorRotation(FMath::RInterpTo(GetActorRotation(), NewRotation, DeltaTime, 0.1f));
 }
 
 bool AEnemyShip::CanMove(const AMyShip* MyShip) const

--- a/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.h
+++ b/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.h
@@ -63,9 +63,9 @@ public:
 	bool bCanFireCannon = true;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	float DistanceToMyShip = 7000.0f;
+	float DistanceToMyShip = 5000.0f;
 
-	const float DistanceToObserveMyShip = 22000.0f;
+	const float DistanceToObserveMyShip = 25000.0f;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	USphereComponent* SphereComponent;


### PR DESCRIPTION
적 배가 deltatime에 따라 부드럽게 회전하도록 수정
적 배의 이동/공격 가능 거리를 측정할 때, navigation의 목적지까지의 거리와 비교하도록 수정