### PR TITLE
CSS-325 [QA] PlayerController의 조작이, 클라이언트에서 Player의 개수만큼 실행되는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -45,41 +45,18 @@ AMyPlayerController::AMyPlayerController()
 void AMyPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
-	
-	TArray<AActor*> FoundShips;
-	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AMyShip::StaticClass(), FoundShips);
-	if (FoundShips.Num() > 0)
-	{
-		Ship = Cast<AMyShip>(FoundShips[0]);
-	}
-
-	Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(GetLocalPlayer());
-	if (Subsystem != nullptr)
-	{
-		Subsystem->AddMappingContext(DefaultMappingContext, 0);
-	}
 
 	if (HasAuthority() && IsLocalController())
 	{
-		Player = Cast<AMyCharacter>(GetPawn());
-		if (Player)
-		{
-			ControlledActor = Player;
-			if (Player->InputComponent)
-			{
-				SetupPlayerInputComponent(Player->InputComponent);
-			}
-		}
+		SetServerCharacter();
 	}
 
 	CurrentControlMode = ControlMode::CHARACTER;
 
-	if(Ship)
-	{
-		SetViewTarget(Ship->Camera_Character);
-	}
-
+	Ship = Cast<AMyShip>(UGameplayStatics::GetActorOfClass(GetWorld(), AMyShip::StaticClass()));
 	SailingSystem = Cast<ASailingSystem>(UGameplayStatics::GetActorOfClass(GetWorld(), ASailingSystem::StaticClass()));
+
+	SetViewTarget(Ship->Camera_Character);
 	
 	if (IsLocalController())
 	{
@@ -90,6 +67,9 @@ void AMyPlayerController::BeginPlay()
 		PopupUpgrade->SpeedUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipMoveSpeed);
 		PopupUpgrade->HandlingUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipHandling);
 		PopupUpgrade->CannonAttackUpgrade->OnClickUpgradeDelegate.AddUObject(this, &AMyPlayerController::UpgradeMyShipCannonAttack);
+
+		Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(GetLocalPlayer());
+		Subsystem->AddMappingContext(DefaultMappingContext, 0);
 	}
 	
 	EnableCheats();
@@ -110,25 +90,10 @@ void AMyPlayerController::BeginPlay()
 void AMyPlayerController::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
-	if (!HasAuthority())
-	{
-		if (!Player || flag)
-		{
-			Player = Cast<AMyCharacter>(GetPawn());
-			GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player NULL"));
 	
-			if (Player)
-			{
-				ControlledActor = Player;
-				if (Player->InputComponent)
-				{
-					SetupPlayerInputComponent(Player->InputComponent);
-					GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player Component NOT NULL"));
-					flag = false;
-					SetViewTarget(Ship->Camera_Character);
-				}
-			}
-		}
+	if (!HasAuthority() && bIsNeedToSetClientCharacter)
+	{
+		SetClientCharacter();
 	}
 
 	// 키를 누르고 있으면 시간을 측정
@@ -178,6 +143,39 @@ void AMyPlayerController::Move(const FInputActionInstance& Instance)
 	if (CurrentStrategy != nullptr && CurrentControlMode != ControlMode::TELESCOPE && CurrentControlMode != ControlMode::BED)
 	{
 		CurrentStrategy->Move(Instance, ControlledActor,this, GetWorld()->GetDeltaSeconds());
+	}
+}
+
+void AMyPlayerController::SetServerCharacter()
+{
+	Player = Cast<AMyCharacter>(GetPawn());
+	if (Player)
+	{
+		ControlledActor = Player;
+		if (Player->InputComponent)
+		{
+			SetupPlayerInputComponent(Player->InputComponent);
+		}
+	}
+}
+
+void AMyPlayerController::SetClientCharacter()
+{
+	if (!Player)
+	{
+		if (AMyCharacter* CastedMyCharacter = Cast<AMyCharacter>(GetPawn()))
+		{
+			Player = CastedMyCharacter;
+			ControlledActor = Player;
+		}
+	}
+	else
+	{
+		if (Player->InputComponent)
+		{
+			SetupPlayerInputComponent(Player->InputComponent);
+			bIsNeedToSetClientCharacter = false;
+		}
 	}
 }
 

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -64,18 +64,21 @@ void AMyPlayerController::BeginPlay()
 		Subsystem->AddMappingContext(DefaultMappingContext, 0);
 	}
 
-	Player = Cast<AMyCharacter>(GetPawn());
-	if (Player)
+	if (HasAuthority())
 	{
-		ControlledActor = Player;
-		if (Player->InputComponent)
+		Player = Cast<AMyCharacter>(GetPawn());
+		if (Player)
 		{
-			SetupPlayerInputComponent(Player->InputComponent);
+			ControlledActor = Player;
+			if (Player->InputComponent)
+			{
+				SetupPlayerInputComponent(Player->InputComponent);
+			}
 		}
-	}
-	else
-	{
-		GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player NULL"));
+		else
+		{
+			GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player NULL"));
+		}
 	}
 
 	CurrentControlMode = ControlMode::CHARACTER;

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -45,12 +45,7 @@ AMyPlayerController::AMyPlayerController()
 void AMyPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
-
-	if (HasAuthority())
-	{
-		GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("HasAutority"));
-	}
-
+	
 	TArray<AActor*> FoundShips;
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AMyShip::StaticClass(), FoundShips);
 	if (FoundShips.Num() > 0)
@@ -64,18 +59,17 @@ void AMyPlayerController::BeginPlay()
 		Subsystem->AddMappingContext(DefaultMappingContext, 0);
 	}
 
-	Player = Cast<AMyCharacter>(GetPawn());
-	if (Player)
+	if (HasAuthority() && IsLocalController())
 	{
-		ControlledActor = Player;
-		if (Player->InputComponent)
+		Player = Cast<AMyCharacter>(GetPawn());
+		if (Player)
 		{
-			SetupPlayerInputComponent(Player->InputComponent);
+			ControlledActor = Player;
+			if (Player->InputComponent)
+			{
+				SetupPlayerInputComponent(Player->InputComponent);
+			}
 		}
-	}
-	else
-	{
-		GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player NULL"));
 	}
 
 	CurrentControlMode = ControlMode::CHARACTER;
@@ -99,6 +93,18 @@ void AMyPlayerController::BeginPlay()
 	}
 	
 	EnableCheats();
+
+	if (IsLocalController())
+	{
+		if (HasAuthority())
+        {
+        	GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("Server"));
+        }
+        else
+        {
+        	GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("Client"));
+        }
+	}
 }
 
 void AMyPlayerController::Tick(float DeltaSeconds)
@@ -160,7 +166,6 @@ void AMyPlayerController::SetupPlayerInputComponent(UInputComponent* PlayerInput
 void AMyPlayerController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
-	Player = Cast<AMyCharacter>(InPawn);
 }
 
 void AMyPlayerController::Move(const FInputActionInstance& Instance)

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.cpp
@@ -45,7 +45,12 @@ AMyPlayerController::AMyPlayerController()
 void AMyPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
-	
+
+	if (HasAuthority())
+	{
+		GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("HasAutority"));
+	}
+
 	TArray<AActor*> FoundShips;
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AMyShip::StaticClass(), FoundShips);
 	if (FoundShips.Num() > 0)
@@ -59,17 +64,18 @@ void AMyPlayerController::BeginPlay()
 		Subsystem->AddMappingContext(DefaultMappingContext, 0);
 	}
 
-	if (HasAuthority() && IsLocalController())
+	Player = Cast<AMyCharacter>(GetPawn());
+	if (Player)
 	{
-		Player = Cast<AMyCharacter>(GetPawn());
-		if (Player)
+		ControlledActor = Player;
+		if (Player->InputComponent)
 		{
-			ControlledActor = Player;
-			if (Player->InputComponent)
-			{
-				SetupPlayerInputComponent(Player->InputComponent);
-			}
+			SetupPlayerInputComponent(Player->InputComponent);
 		}
+	}
+	else
+	{
+		GEngine->AddOnScreenDebugMessage(-1, 5.0f, FColor::Red, TEXT("Player NULL"));
 	}
 
 	CurrentControlMode = ControlMode::CHARACTER;
@@ -93,18 +99,6 @@ void AMyPlayerController::BeginPlay()
 	}
 	
 	EnableCheats();
-
-	if (IsLocalController())
-	{
-		if (HasAuthority())
-        {
-        	GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("Server"));
-        }
-        else
-        {
-        	GEngine->AddOnScreenDebugMessage(-1, 60.0f, FColor::Emerald, TEXT("Client"));
-        }
-	}
 }
 
 void AMyPlayerController::Tick(float DeltaSeconds)
@@ -166,6 +160,7 @@ void AMyPlayerController::SetupPlayerInputComponent(UInputComponent* PlayerInput
 void AMyPlayerController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
+	Player = Cast<AMyCharacter>(InPawn);
 }
 
 void AMyPlayerController::Move(const FInputActionInstance& Instance)

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
@@ -85,15 +85,12 @@ private:
 	// 키를 누른 시점부터의 시간을 측정하기 위한 변수
 	float PressDuration = 0.0f;
 
-	void SetServerCharacter();
-	void SetClientCharacter();
-	
 	void Interaction_Pressed();
 	void Interaction_Trigger();
 	void Interaction_Released();
 	
 	void DraggingRotate(const FInputActionInstance& Instance);
-	
+
 	FTimerHandle HealthTimerHandle;
 	
 public:
@@ -186,5 +183,5 @@ protected:
 	FRotator TargetRotation;
 	float ChangeSpeed = 5.0f;
 
-	bool bIsNeedToSetClientCharacter = true;
+	bool flag = true;
 };

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
@@ -87,6 +87,8 @@ private:
 
 	void SetServerCharacter();
 	void SetClientCharacter();
+
+	void ShowAuthorityDebugMessage() const;
 	
 	void Interaction_Pressed();
 	void Interaction_Trigger();

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
@@ -87,8 +87,6 @@ private:
 
 	void SetServerCharacter();
 	void SetClientCharacter();
-
-	void ShowAuthorityDebugMessage() const;
 	
 	void Interaction_Pressed();
 	void Interaction_Trigger();

--- a/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
+++ b/capstone_2024_20/Source/capstone_2024_20/MyPlayerController.h
@@ -85,12 +85,15 @@ private:
 	// 키를 누른 시점부터의 시간을 측정하기 위한 변수
 	float PressDuration = 0.0f;
 
+	void SetServerCharacter();
+	void SetClientCharacter();
+	
 	void Interaction_Pressed();
 	void Interaction_Trigger();
 	void Interaction_Released();
 	
 	void DraggingRotate(const FInputActionInstance& Instance);
-
+	
 	FTimerHandle HealthTimerHandle;
 	
 public:
@@ -183,5 +186,5 @@ protected:
 	FRotator TargetRotation;
 	float ChangeSpeed = 5.0f;
 
-	bool flag = true;
+	bool bIsNeedToSetClientCharacter = true;
 };


### PR DESCRIPTION
사이드 이펙트 방지를 위해 기존 수정사항 일체 revert 하고, 원인인 코드만 수정.
BeginPlay에서 클라이언트가 간헐적으로 InputComponent가 바인딩되는 것이 원인으로, BeginPlay에서는 이를 서버만 실행 가능하도록 수정