### PR TITLE
CSS-307 [QA] 적이 해적에게 근접해올 때, 겹칠 수 있는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/EnemyShip/EnemyShip.cpp
@@ -183,22 +183,24 @@ TArray<UEnemySpawnPoint*> AEnemyShip::GetEnemySpawnPointsToSpawn(const AMyShip* 
 		Distances.Add(Distance);
 	}
 
-	int FirstNearestIndex = 0;
-	int SecondNearestIndex = 0;
-	int ThirdNearestIndex = 0;
+	int FirstNearestIndex = -1;
+	int SecondNearestIndex = -1;
+	int ThirdNearestIndex = -1;
 
 	for (int i = 0; i < Distances.Num(); i++)
 	{
-		if (Distances[i] < Distances[FirstNearestIndex])
+		if ( FirstNearestIndex == -1 || Distances[i] < Distances[FirstNearestIndex])
 		{
+			ThirdNearestIndex = SecondNearestIndex;
 			SecondNearestIndex = FirstNearestIndex;
 			FirstNearestIndex = i;
 		}
-		else if (Distances[i] < Distances[SecondNearestIndex])
+		else if (SecondNearestIndex == -1 || Distances[i] < Distances[SecondNearestIndex])
 		{
+			ThirdNearestIndex = SecondNearestIndex;
 			SecondNearestIndex = i;
 		}
-		else if (Distances[i] < Distances[ThirdNearestIndex])
+		else if (ThirdNearestIndex == -1 || Distances[i] < Distances[ThirdNearestIndex])
 		{
 			ThirdNearestIndex = i;
 		}


### PR DESCRIPTION
생성 알고리즘 버그 수정: 적 배 충돌 위치로부터 가장 가까운 세 스폰 포인트를 정상적으로 찾도록 수정