### PR TITLE
CSS-356 [QA] 항해_해적_클라이언트에서 2, 3번 캐릭터가 공격 시 크래시가 일어나는 문제

### DIFF
--- a/capstone_2024_20/Source/capstone_2024_20/MyCharacter.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/MyCharacter.cpp
@@ -77,14 +77,11 @@ void AMyCharacter::Tick(float DeltaTime)
 	// ! 캐릭터에 Attach한 UI가 Movement에 따라 움직이는 문제가 있어, Tick에서 위치를 업데이트
 	TextWidget->SetWorldLocation(GetActorLocation() + FVector(0.0f, 0.0f, -200.0f));
 
-	if (PirateAnimInstance == nullptr)
+	PirateAnimInstance = Cast<UPirateAnimInstance>(GetMesh()->GetAnimInstance());
+	if (PirateAnimInstance)
 	{
-		PirateAnimInstance = Cast<UPirateAnimInstance>(GetMesh()->GetAnimInstance());
-		if (PirateAnimInstance)
-		{
-			PirateAnimInstance->OnPirateGiveDamageDelegate.BindUObject(this, &AMyCharacter::GiveDamage);
-			PirateAnimInstance->OnPirateAttackEndDelegate.BindUObject(this, &AMyCharacter::AttackEnd);
-		}
+		PirateAnimInstance->OnPirateGiveDamageDelegate.BindUObject(this, &AMyCharacter::GiveDamage);
+		PirateAnimInstance->OnPirateAttackEndDelegate.BindUObject(this, &AMyCharacter::AttackEnd);
 	}
 }
 

--- a/capstone_2024_20/Source/capstone_2024_20/Pirate/PirateAnimInstance.cpp
+++ b/capstone_2024_20/Source/capstone_2024_20/Pirate/PirateAnimInstance.cpp
@@ -2,12 +2,18 @@
 
 void UPirateAnimInstance::OnAttackEnd() const
 {
-	OnPirateAttackEndDelegate.Execute();
+	if (OnPirateAttackEndDelegate.IsBound())
+	{
+		OnPirateAttackEndDelegate.Execute();
+	}
 }
 
 // ! 사이드 이펙트를 막기 위함
 // ReSharper disable once CppUE4BlueprintCallableFunctionMayBeConst
 void UPirateAnimInstance::OnGiveDamage()
 {
-	OnPirateGiveDamageDelegate.Execute();
+	if (OnPirateGiveDamageDelegate.IsBound())
+	{
+		OnPirateGiveDamageDelegate.Execute();
+	}
 }


### PR DESCRIPTION
AnimInstance 참조와 함수 바인딩 모두 tick에서 처리하도록 변경